### PR TITLE
Add hook when creating entries from the controller

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -21,10 +21,12 @@ use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
+use Statamic\Support\Traits\Hookable;
 
 class EntriesController extends CpController
 {
     use ExtractsFromEntryFields,
+        Hookable,
         QueriesFilters;
 
     public function index(FilteredRequest $request, $collection)
@@ -300,7 +302,11 @@ class EntriesController extends CpController
             $blueprint->ensureFieldHasConfig('author', ['visibility' => 'read_only']);
         }
 
-        $values = Entry::make()->collection($collection)->values()->all();
+        $entry = Entry::make()->collection($collection);
+
+        $this->runHooks('creating-entry', $entry);
+
+        $values = $entry->values()->all();
 
         if ($collection->hasStructure() && $request->parent) {
             $values['parent'] = $request->parent;


### PR DESCRIPTION
- Fork of the current state of statamic/cms#8643 for local patching
- Fire `EntriesController::creating-entry` hook when creating a new entry in the control panel
- Allow dynamic default values 

**Usage**

```php
// app/Providers/AppServiceProvider.php

EntriesController::hook('creating-entry', function ($entry) {
  $entry->set('rand', random_int(1, 9999));
});