### PR TITLE
Generate glide url without site root prepended

### DIFF
--- a/src/Imaging/GlideUrlBuilder.php
+++ b/src/Imaging/GlideUrlBuilder.php
@@ -64,6 +64,6 @@ class GlideUrlBuilder extends ImageUrlBuilder
             $params['mark'] = 'asset::'.Str::toBase64Url($asset->containerId().'/'.$asset->path());
         }
 
-        return URL::prependSiteRoot($builder->getUrl($path, $params));
+        return $builder->getUrl($path, $params);
     }
 }


### PR DESCRIPTION
- Disable site root being automatically prepended to Glide urls
- Fixes issues with CDN caching and SEO
- Mostly here to use as composer patch